### PR TITLE
Unable to test with Xcode generated StoreKit transaction

### DIFF
--- a/Sources/App/Application+configure.swift
+++ b/Sources/App/Application+configure.swift
@@ -26,7 +26,8 @@ extension HBApplication {
         self.httpClient = HTTPClient(eventLoopGroupProvider: .shared(self.eventLoopGroup))
         
         // 2. Add logging middleware
-        self.logger.logLevel = .info
+        let logLevel = HBEnvironment().get("logLevel") ?? "info"
+        self.logger.logLevel = .init(rawValue: logLevel) ?? .info
         self.middleware.add(HBLogRequestsMiddleware(.info))
         self.middleware.add(HBLogRequestsMiddleware(.debug))
         self.middleware.add(HBLogRequestsMiddleware(.error))


### PR DESCRIPTION
AppStoreAuthenticator.authenticate attempts to validate a JWS payload by calling validateJWS method starting with production environment and then trying lower environments. However, validateJWS throws HBHTTPError(.unauthorized) exception when JWS verification fails for any reason.
In case of JWT representation of a purchase transaction is made by Xcode StoreKit Testing framework, it's not signed by App Store, and ChainVerifier.verify method in AppStore Server Library has a workaround, in which it skips more rigorous checks for Xcode environment.

I also added an environment variable logLevel, which is used to set the default logger level for better debugging.