### PR TITLE
Making PicoAIProxy instance environment bound

### DIFF
--- a/Sources/App/Application+configure.swift
+++ b/Sources/App/Application+configure.swift
@@ -28,6 +28,7 @@ extension HBApplication {
         // 2. Add logging middleware
         let logLevel = HBEnvironment().get("logLevel") ?? "info"
         self.logger.logLevel = .init(rawValue: logLevel) ?? .info
+        self.logger.info("Logger level is set to \(self.logger.logLevel)")
         self.middleware.add(HBLogRequestsMiddleware(.info))
         self.middleware.add(HBLogRequestsMiddleware(.debug))
         self.middleware.add(HBLogRequestsMiddleware(.error))


### PR DESCRIPTION
The PR is based on a comment from a user on my fork requesting an upstream merge.

This change introduces a new environment variable `environment`, which makes the instance bound to validate requests destined for that specific environment. It is somewhat opinionated in the way the environment is defined and the way it affects the validation process. By default, if no value is provided in the `environment` variable, it is considered `Production` (as defined in `Environment` structure of AppStoreServerLibrary.)

The validation rules are as follows:
- If the instance is bound to `Production` environment, it will first attempt to validate an incoming transaction as a real production transaction, i.e. coming from a real device and the app (not a TestFlight or Xcode simulator). If this fails, it'll attempt to validate the transaction as a TestFlight one. If the transaction is neither prod nor TestFlight, the validation fails. Thus, the same PicoAIProxy can be used for both Production and TestFlight users.
- Else (i.e. if the instance is NOT bound to `Production` environment), it will use the validation logic for that environment assuming that the request environment matches the instance environment. For example, this allows us to have a separate environment for TestFlight requests and another one for Xcode simulator requests.

The benefit of this approach for indie developers is that I can have my local (docker or Xcode) instance of Pico for validating my simulator requests, while having a cloud deployed instance for my production and TestFlight users.

Please consider a potential impact of this logic on those who already use the original version of Pico.

Thanks!